### PR TITLE
chore: Fixed POC usage of ConfigMaps

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -14,8 +14,8 @@ import (
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
-	"github.com/lance/js-function-operator/pkg/apis"
-	"github.com/lance/js-function-operator/pkg/controller"
+	"github.com/openshift-cloud-functions/js-function-operator/pkg/apis"
+	"github.com/openshift-cloud-functions/js-function-operator/pkg/controller"
 
 	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
 	"github.com/operator-framework/operator-sdk/pkg/leader"

--- a/deploy/crds/faas_v1alpha1_jsfunction_cr.yaml
+++ b/deploy/crds/faas_v1alpha1_jsfunction_cr.yaml
@@ -6,7 +6,7 @@ spec:
   # Add fields here
   func: | 
     const http = require('http');
-    const port = 8080;
+    const port = 8181;
 
     const handler = (request, response) => {
       console.log(request.url);

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -16,7 +16,7 @@ spec:
       containers:
         - name: js-function-operator
           # Replace this with the built image name
-          image: quay.io/lanceball/js-function-operator:v0.0.1
+          image: docker.io/rhuss/js-function-operator:v0.0.1
           command:
           - js-function-operator
           imagePullPolicy: Always

--- a/pkg/apis/addtoscheme_faas_v1alpha1.go
+++ b/pkg/apis/addtoscheme_faas_v1alpha1.go
@@ -1,7 +1,7 @@
 package apis
 
 import (
-	"github.com/lance/js-function-operator/pkg/apis/faas/v1alpha1"
+	"github.com/openshift-cloud-functions/js-function-operator/pkg/apis/faas/v1alpha1"
 )
 
 func init() {

--- a/pkg/controller/add_jsfunction.go
+++ b/pkg/controller/add_jsfunction.go
@@ -1,7 +1,7 @@
 package controller
 
 import (
-	"github.com/lance/js-function-operator/pkg/controller/jsfunction"
+	"github.com/openshift-cloud-functions/js-function-operator/pkg/controller/jsfunction"
 )
 
 func init() {


### PR DESCRIPTION
I added the following changes:

• The ConfigMap created was never stored on the cluster
• The Volume definition needs to be part of the PodSpec, it's not a standalone entity.
• I had to change to port 8181 as port 8080 seems to be already occupied
• I had to switch to `docker.io/rhuss/js-runtime` (which is a clone of `quay.io/lanceball/js-runtime`) because OpenShift doesn't work with quay.io yet (different registry format)

It has been tested with the sample CR from the repo.